### PR TITLE
Point pageship to `oursky.app`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,5 +33,5 @@ jobs:
         run: npm run build
       - name: Deploy
         env:
-          PAGESHIP_API: https://api.pages.pandawork.com
+          PAGESHIP_API: https://api.pages.oursky.app
         run: make deploy

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - do-not-run-cd # dont run cd until pageship deployment with github OIDC token is resolved
+      - main
 
 jobs:
   cd:
@@ -29,7 +29,7 @@ jobs:
           elif [[ "${{ github.ref_name }}" == "production" ]]; then
             echo "ENV=production" >> $GITHUB_ENV
           fi
-      - name: build html
+      - name: Build html
         run: npm run build
       - name: Deploy
         env:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ##################################
 
 PYTHON_PREFIX := python3 -m
-PAGESHIP_API := https://api.pages.pandawork.com
+PAGESHIP_API := https://api.pages.oursky.app
 
 ifeq ($(GITHUB_REF_NAME),production)
 ENV ?= $(GITHUB_REF_NAME)

--- a/pageship.production.toml
+++ b/pageship.production.toml
@@ -1,5 +1,5 @@
 [app]
-id = "mockuphone-prod-clone"
+id = "mockuphone-prod"
 
 team = [
     # Allow GitHub Actions in your repo to deploy
@@ -15,9 +15,9 @@ team = [
 [[app.sites]]
 name = "main"
 
-# [[app.domains]]
-# domain = "mockuphone.com"
-# site = "main"
+[[app.domains]]
+domain = "mockuphone.com"
+site = "main"
 
 [site]
 public = "dist"

--- a/pageship.staging.toml
+++ b/pageship.staging.toml
@@ -1,5 +1,5 @@
 [app]
-id = "mockuphone-staging-clone"
+id = "mockuphone-staging"
 
 team = [
     # Allow GitHub Actions in your repo to deploy
@@ -15,9 +15,9 @@ team = [
 [[app.sites]]
 name = "main"
 
-# [[app.domains]]
-# domain = "staging.mockuphone.com"
-# site = "main"
+[[app.domains]]
+domain = "staging.mockuphone.com"
+site = "main"
 
 [site]
 public = "dist"


### PR DESCRIPTION
See below, will `pageship activate staging.mockuphone.com` once DNS record is set up in [MUP-69](https://linear.app/oursky/issue/MUP-69/use-pageship-for-stagingmockuphone)


```sh
$ PAGESHIP_API=https://api.pages.oursky.app pageship domains
NAME                      SITE                       CREATED AT    STATUS
staging.mockuphone.com    mockuphone-staging/main    -             INACTIVE

  INFO   To setup custom domain, set DNS A record pointing to `34.80.125.128`.
```