### PR TITLE
Fix wrong timezone of the file generated datetime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ check-format:
 	# TODO: upgrade prettier to 3.1 when it is available
 	npx prettier --check "**/*" --ignore-unknown
 
+# ref https://superuser.com/a/1170997
+.PHONY: bundle-python
+bundle-python:
+	ditto -c -k --sequesterRsrc --keepParent ./mockup_package/mockup ./public/mockup.zip
+
 .PHONY: lint_astro
 lint_astro:
 	python3 -m ruff .

--- a/public/scripts/download-python-package.js
+++ b/public/scripts/download-python-package.js
@@ -22,6 +22,15 @@ function dataURLtoFile(dataurl, filename) {
   return new File([u8arr], filename, { type: mime });
 }
 
+function getJSZipDateWithOffset() {
+  // copied workaround to fix JSZip bug https://github.com/Stuk/jszip/issues/369#issuecomment-388324954
+  const currDate = new Date();
+  const dateWithOffset = new Date(
+    currDate.getTime() - currDate.getTimezoneOffset() * 60000,
+  );
+
+  return dateWithOffset;
+}
 async function generateZIP() {
   var zip = new JSZip();
   var count = 0;
@@ -36,7 +45,10 @@ async function generateZIP() {
     var filename = unescape(k.substring(3, k.length)) + ".png";
     var image = await fetch(imgURL);
     var imageBlob = await image.blob();
-    zip.file(filename, imageBlob, { binary: true });
+    zip.file(filename, imageBlob, {
+      binary: true,
+      date: getJSZipDateWithOffset(),
+    });
     count++;
     if (count == images.size) {
       zip.generateAsync({ type: "blob" }).then(function (content) {


### PR DESCRIPTION
Realized it's [JSZip issue (known since 2016)](https://github.com/Stuk/jszip/issues/369), copied workaround from there

## Preview

<img width="503" alt="image" src="https://github.com/oursky/mockuphone.com/assets/74223769/048b8172-bf2f-4305-9704-2b975550f12d">
