### PR TITLE
Fix non-existent `npm ci` script as `make ci`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm ci
+      - run: make ci
       - name: Set env to staging/production
         run: |
           if [[ "${{ github.ref_name }}" == "main" ]]; then


### PR DESCRIPTION
There's no `npm ci` at all 🐵 

Changed to `make ci`