### PR TITLE
Remove ci in cd first

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: make ci
       - name: Set env to staging/production
         run: |
           if [[ "${{ github.ref_name }}" == "main" ]]; then


### PR DESCRIPTION
## Rationale
We should somehow make `cd.yaml` depends on `ci.yaml` jobs

## Problem
Currently, `ci` and `cd` runs con-currently.