### PR TITLE
Fix cannot preview mockup issue for some devices

### DIFF
--- a/src/scripts/device_info.json
+++ b/src/scripts/device_info.json
@@ -2543,8 +2543,7 @@
           "name": "front"
         }
       ],
-      "available_perspectives": ["Front"],
-      "is_legacy": true
+      "available_perspectives": ["Front"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -2572,8 +2571,7 @@
           "name": "front"
         }
       ],
-      "available_perspectives": ["Front"],
-      "is_legacy": true
+      "available_perspectives": ["Front"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3171,8 +3169,7 @@
           "name": "front"
         }
       ],
-      "available_perspectives": ["Front"],
-      "is_legacy": true
+      "available_perspectives": ["Front"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3200,8 +3197,7 @@
           "name": "front"
         }
       ],
-      "available_perspectives": ["Front"],
-      "is_legacy": true
+      "available_perspectives": ["Front"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3229,8 +3225,7 @@
           "name": "front"
         }
       ],
-      "available_perspectives": ["Front"],
-      "is_legacy": true
+      "available_perspectives": ["Front"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3268,8 +3263,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3307,8 +3301,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3346,8 +3339,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "background_class": "fish-bg2",
@@ -3385,8 +3377,7 @@
           "name": "side"
         }
       ],
-      "available_perspectives": ["Front", "Side"],
-      "is_legacy": true
+      "available_perspectives": ["Front", "Side"]
     },
     {
       "background_class": "fish-bg",
@@ -3463,8 +3454,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3503,8 +3493,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3543,8 +3532,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3583,8 +3571,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3623,8 +3610,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"http://pixelartfactory.com/psd/samsung-galaxy-s4-psd\" target=\"blank\">Pixel Art Factory</a></p>",
@@ -3748,8 +3734,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3788,8 +3773,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",
@@ -3828,8 +3812,7 @@
           "name": "landscape"
         }
       ],
-      "available_perspectives": ["Portrait", "Landscape"],
-      "is_legacy": true
+      "available_perspectives": ["Portrait", "Landscape"]
     },
     {
       "credits": "<p><a href=\"https://design.facebook.com/toolsandresources/devices/\" target=\"blank\">Meta - Design Resources</a></p>",


### PR DESCRIPTION
Ref: MUP-155, MUP-154, MUP-156

checking our code, we are using templates with `"is_legacy": true` in `devices_picture/` and using templates in `mockup_template/` for other devices, so this update just changes the templates we use for some devices.

below devices don't have template with transparent background, so cannot fix now:

- apple-imac2013
- apple-imac2015
- apple-macbook
- lg-55lw5600
- lg-tm2792
- samsung-d8000
- samsung-es8000
- samsung-galaxys4
- google-pixel-really-blue
- google-pixel-quite-black
- google-pixel-very-silver