### PR TITLE
Fix preview icon was not selected when uploading only one image

### DIFF
--- a/public/scripts/upload.js
+++ b/public/scripts/upload.js
@@ -164,15 +164,15 @@ class FileListViewModel {
       await imageUpload.read();
       imageUpload.ulid = ULID.ulid();
 
+      if (window.viewModel.selectedPreviewImageULID === null && i === 0) {
+        window.viewModel.selectedPreviewImageULID = imageUpload.ulid;
+      }
       // Avoiding read same image file
       setTimeout(() => {
         this._imageUploads.push(imageUpload);
         window.viewModel.generatePreviewMockup(imageUpload);
       }, i * 10);
     }
-
-    window.viewModel.selectedPreviewImageULID =
-      window.viewModel.defaultImageUploadULID;
   }
 
   async remove(filename, fileUlid) {


### PR DESCRIPTION
Ref: MUP-134

this issue only happen when uploading only one image, update the logic of setting `selectedPreviewImageULID`


https://github.com/user-attachments/assets/018a7e67-332e-4c3d-988e-62d82ca54c19

