### PR TITLE
Handle filename overflow in loading state

### DIFF
--- a/src/styles/upload.css
+++ b/src/styles/upload.css
@@ -350,7 +350,7 @@ main {
   display: flex;
 
   .file-list-item__file-info {
-    max-width: calc(100%);
+    max-width: 100%;
   }
 
   &.file-list-item__previewable {

--- a/src/styles/upload.css
+++ b/src/styles/upload.css
@@ -349,6 +349,10 @@ main {
 .file-list-item {
   display: flex;
 
+  .file-list-item__file-info {
+    max-width: calc(100%);
+  }
+
   &.file-list-item__previewable {
     gap: 4px;
 


### PR DESCRIPTION
Ref: MUP-169

I remember I saw this issue and fix it before, maybe missing when update something. :sadfrog:


https://github.com/user-attachments/assets/cf3ba24c-6950-496d-abc7-8f186196b0c0

