### PR TITLE
Workaround firefox worker init fail by limiting firefox workers to 2

### DIFF
--- a/public/scripts/upload.js
+++ b/public/scripts/upload.js
@@ -56,8 +56,20 @@ async function runWorker(worker) {
 }
 
 const MAX_FIREFOX_WEB_WORKERS = 2;
+const DEFAULT_MAX_WEB_WORKERS = 4; // most CPUs at least have 4 cores nowadays
 function isUserAgentFirefox() {
   return navigator.userAgent.match(/firefox|fxios/i);
+}
+
+function getMaxWorkers() {
+  if (isUserAgentFirefox()) {
+    return MAX_FIREFOX_WEB_WORKERS;
+  }
+  if (navigator.hardwareConcurrency == null) {
+    // browser does not support navigator.hardwareConcurrency, fallback to default
+    return DEFAULT_MAX_WEB_WORKERS;
+  }
+  return navigator.hardwareConcurrency;
 }
 
 function runPreviewWorker(worker, imageUpload) {
@@ -234,9 +246,7 @@ class RootViewModel {
     this.maxMockupWaitSec = maxMockupWaitSec;
     this.fileList = fileListViewModel;
 
-    this.maxWorkers = isUserAgentFirefox()
-      ? MAX_FIREFOX_WEB_WORKERS
-      : navigator.hardwareConcurrency;
+    this.maxWorkers = getMaxWorkers();
 
     // Reserve one worker to generate the final mockup, will update later
     for (let i = 0; i < this.maxWorkers - 1; i += 1) {

--- a/public/scripts/upload.js
+++ b/public/scripts/upload.js
@@ -55,6 +55,11 @@ async function runWorker(worker) {
   );
 }
 
+const MAX_FIREFOX_WEB_WORKERS = 2;
+function isUserAgentFirefox() {
+  return navigator.userAgent.match(/firefox|fxios/i);
+}
+
 function runPreviewWorker(worker, imageUpload) {
   const imageUploadFile = imageUpload.file;
   worker.worker.postMessage({
@@ -211,7 +216,7 @@ class RootViewModel {
   _isGeneratingMockup = false;
   worker = new Worker("/scripts/web_worker.js");
   workerPool = [];
-  maxWorkers = 4;
+  maxWorkers = 0;
   selectedColorId = null;
   selectedPreviewImageULID = null;
 
@@ -228,7 +233,10 @@ class RootViewModel {
     this.selectedColorId = selectedColorId;
     this.maxMockupWaitSec = maxMockupWaitSec;
     this.fileList = fileListViewModel;
-    this.maxWorkers = navigator.hardwareConcurrency || 4;
+
+    this.maxWorkers = isUserAgentFirefox()
+      ? MAX_FIREFOX_WEB_WORKERS
+      : navigator.hardwareConcurrency;
 
     // Reserve one worker to generate the final mockup, will update later
     for (let i = 0; i < this.maxWorkers - 1; i += 1) {


### PR DESCRIPTION
ref MUP-178

@YayunHuang I also experienced `firefox always fail`, which can be resolved by `quitting firefox -> open again`
EDIT: by `resolved`, I mean `seeing code changes have effects in localhost`

I really don't like what I do in this PR, but guess this workaround 
- enable staging/prod to be used in firefox;
- although significantly lower the preview speed.

Sidenote - maybe we should add some `Recommend to use on Chrome`?